### PR TITLE
Local ddb

### DIFF
--- a/src/Network/Skylark/Core/Conf.hs
+++ b/src/Network/Skylark/Core/Conf.hs
@@ -48,15 +48,6 @@ port =
     <> metavar "PORT"
     <> help    "Port to listen on"
 
--- | Parse DDB port.
---
-ddbPort :: Parser Int
-ddbPort =
-  option auto
-    $  long    "ddb-port"
-    <> metavar "PORT"
-    <> help    "DDB port (for testing: 8000)"
-
 -- | Parse connection timeout.
 --
 timeout :: Parser Int
@@ -101,6 +92,14 @@ metrics =
     $  long "metrics"
     <> help "Metrics Collection"
 
+-- | Local DDB.
+--
+localDdb :: Parser Bool
+localDdb =
+  switch
+    $  long "local-ddb"
+    <> help "Use Local Dynamo DB"
+
 bool :: Parser Bool -> Parser (Maybe Bool)
 bool =
   fmap $ \b ->
@@ -116,7 +115,7 @@ parseConf = Conf    <$>
   optional logLevel <*>
   optional appName  <*>
   bool metrics      <*>
-  optional ddbPort
+  bool localDdb
 
 -- | Produce a full command line options parser.
 --

--- a/src/Network/Skylark/Core/Types.hs
+++ b/src/Network/Skylark/Core/Types.hs
@@ -77,8 +77,7 @@ data Conf = Conf
   , _confLogLevel :: Maybe LogLevel -- ^ Logging level
   , _confAppName  :: Maybe Text     -- ^ Name of the application
   , _confMetrics  :: Maybe Bool     -- ^ Enable metrics collection
-  , _confDdbPort  :: Maybe Int      -- ^ Port of local DDB instance (if testing)
-                                    -- If unset, default to prod configuration.
+  , _confLocalDdb :: Maybe Bool     -- ^ Use a local DDB instance
   } deriving ( Eq, Show )
 
 $(makeClassy ''Conf)
@@ -104,7 +103,7 @@ instance Default Conf where
     , _confLogLevel = Just LevelInfo
     , _confAppName  = Nothing
     , _confMetrics  = Nothing
-    , _confDdbPort  = Nothing
+    , _confLocalDdb = Nothing
     }
 
 instance FromJSON Conf where
@@ -128,7 +127,7 @@ instance FromEnv Conf where
       envMaybe "SKYLARK_LOG_LEVEL" <*>
       envMaybe "SKYLARK_APP_NAME"  <*>
       envMaybe "SKYLARK_METRICS"   <*>
-      envMaybe "SKYLARK_DDB_PORT"
+      envMaybe "SKYLARK_LOCAL_DDB"
 
 instance Monoid Conf where
   mempty = Conf
@@ -138,7 +137,7 @@ instance Monoid Conf where
     , _confLogLevel = Nothing
     , _confAppName  = Nothing
     , _confMetrics  = Nothing
-    , _confDdbPort  = Nothing
+    , _confLocalDdb = Nothing
     }
 
   mappend a b = Conf
@@ -148,7 +147,7 @@ instance Monoid Conf where
     , _confLogLevel = merge _confLogLevel a b
     , _confAppName  = merge _confAppName a b
     , _confMetrics  = merge _confMetrics a b
-    , _confDdbPort  = merge _confDdbPort a b
+    , _confLocalDdb = merge _confLocalDdb a b
     }
 
 -- | Given a record field accessor. return the second non-Nothing

--- a/test/Test/Network/Skylark/Core/Conf.hs
+++ b/test/Test/Network/Skylark/Core/Conf.hs
@@ -124,7 +124,7 @@ testEnv =
           , _confLogLevel = Nothing
           , _confAppName  = Nothing
           , _confMetrics  = Nothing
-          , _confDdbPort  = Nothing
+          , _confLocalDdb = Nothing
           }
     , testCase "Port and Timeout" $ do
         unsetEnv "SKYLARK_CONF_FILE"
@@ -139,7 +139,7 @@ testEnv =
           , _confLogLevel = Nothing
           , _confAppName  = Nothing
           , _confMetrics  = Nothing
-          , _confDdbPort  = Nothing
+          , _confLocalDdb = Nothing
           }
      , testCase "String value" $ do
         setEnv "SKYLARK_CONF_FILE" "l"
@@ -154,7 +154,7 @@ testEnv =
           , _confLogLevel = Nothing
           , _confAppName  = Nothing
           , _confMetrics  = Nothing
-          , _confDdbPort  = Nothing
+          , _confLocalDdb = Nothing
           }
      , testCase "LevelInfo" $ do
         unsetEnv "SKYLARK_CONF_FILE"
@@ -169,7 +169,7 @@ testEnv =
           , _confLogLevel = Just LevelInfo
           , _confAppName  = Nothing
           , _confMetrics  = Nothing
-          , _confDdbPort  = Nothing
+          , _confLocalDdb = Nothing
           }
      , testCase "LevelOther" $ do
         unsetEnv "SKYLARK_CONF_FILE"
@@ -184,7 +184,7 @@ testEnv =
           , _confLogLevel = Just (LevelOther "other")
           , _confAppName  = Nothing
           , _confMetrics  = Nothing
-          , _confDdbPort  = Nothing
+          , _confLocalDdb = Nothing
           }
     ]
 
@@ -200,7 +200,7 @@ testDataFileFetch =
           , _confLogLevel = Just LevelDebug
           , _confAppName  = Nothing
           , _confMetrics  = Nothing
-          , _confDdbPort  = Nothing
+          , _confLocalDdb = Nothing
           }
     , testCase "Existing data file" $ do
         c <- getDataFile "conf/dev.yaml"
@@ -211,7 +211,7 @@ testDataFileFetch =
           , _confLogLevel = Just LevelInfo
           , _confAppName  = Nothing
           , _confMetrics  = Nothing
-          , _confDdbPort  = Nothing
+          , _confLocalDdb = Nothing
           }
     ]
 
@@ -304,7 +304,7 @@ testEnvProperties = testGroup "(checked by QuickCheck)"
                   set "SKYLARK_LOG_LEVEL" _confLogLevel
                   set "SKYLARK_APP_NAME"  _confAppName
                   set "SKYLARK_METRICS"   _confMetrics
-                  set "SKYLARK_DDB_PORT"  _confDdbPort
+                  set "SKYLARK_LOCAL_DDB" _confLocalDdb
                   decodeEnv
         Test.QuickCheck.Monadic.assert $ res == Right c
   ]


### PR DESCRIPTION
`local-ddb` flag. Blatantly flag local usage; don't support running ddb instances on other ports.

/cc @ejconlon 
